### PR TITLE
fix: switch from v16 to v20 of NodeJS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ outputs:
     description: "Main deployment inspection url."
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 
 branding:


### PR DESCRIPTION
Bumps the version of NodeJS used to v20 to address these Github Action warnings:

![CleanShot 2024-02-14 at 17 31 19@2x](https://github.com/schupryna/deploy-to-vercel-action/assets/1617209/49b2f235-2232-478d-a0a6-5ca2f1818434)
